### PR TITLE
Use default data location for this redis version

### DIFF
--- a/deploy/redis-persistent-template.yaml
+++ b/deploy/redis-persistent-template.yaml
@@ -115,7 +115,7 @@
                 terminationMessagePath: "/dev/termination-log"
                 volumeMounts: 
                   - 
-                    mountPath: "/var/lib/redis/data"
+                    mountPath: "/data"
                     name: "${DATABASE_SERVICE_NAME}-data"
             dnsPolicy: "ClusterFirst"
             restartPolicy: "Always"


### PR DESCRIPTION
The previous data location caused issues with redis actually accepting connections and storing data, even though the pod appeared to be running without issue.