### PR TITLE
Fixed pods

### DIFF
--- a/deploy/crds/sentry_v1alpha1_sentry_crd.yaml
+++ b/deploy/crds/sentry_v1alpha1_sentry_crd.yaml
@@ -29,9 +29,6 @@ spec:
           type: object
         spec:
           properties:
-            name:
-              description: Name is the distinct name of the Sentry service we're running
-              type: string
             postgresDB:
               description: PostgresDB is the database within postgres we're using
               type: string
@@ -43,8 +40,8 @@ spec:
                 database password
               type: string
             postgresPort:
-              description: PostgresPort is the port on which the database server is
-                listening
+              description: 'PostgresPort is the port on which the database server
+                is listening (defaults: 5432)'
               format: int64
               type: integer
             postgresUser:
@@ -52,29 +49,27 @@ spec:
                 username
               type: string
             redisDB:
-              description: RedisDB is the name of the redis instance we're using
+              description: 'RedisDB is the name of the redis instance we''re using
+                (defaults: "0")'
               type: string
             redisHost:
               description: RedisHost is the name of the server running redis
               type: string
             redisPort:
-              description: RedisPort is the port on which the redis server is listening
+              description: 'RedisPort is the port on which the redis server is listening
+                (defaults: 6379)'
               format: int64
               type: integer
-            sentryVersion:
-              description: SentryVersion is the version of sentry we are running
+            sentryImage:
+              description: 'SentryImage is the image of sentry we are running (defaults:
+                docker.io/sentry:latest)'
               type: string
           required:
-          - name
-          - sentryVersion
           - postgresHost
-          - postgresPort
           - postgresDB
           - postgresUser
           - postgresPassword
           - redisHost
-          - redisPort
-          - redisDB
           type: object
         status:
           properties:

--- a/pkg/apis/sentry/v1alpha1/sentry_types.go
+++ b/pkg/apis/sentry/v1alpha1/sentry_types.go
@@ -14,16 +14,13 @@ type SentrySpec struct {
 	// Important: Run "operator-sdk generate k8s" to regenerate code after modifying this file
 	// Add custom validation using kubebuilder tags: https://book-v1.book.kubebuilder.io/beyond_basics/generating_crd.html
 
-	//Name is the distinct name of the Sentry service we're running
-	Name string `json:"name"`
-
-	//SentryVersion is the version of sentry we are running
-	SentryVersion string `json:"sentryVersion"`
+	//SentryImage is the image of sentry we are running (defaults: docker.io/sentry:latest)
+	SentryImage string `json:"sentryImage,omitempty"`
 
 	//PostgresHost is the name of server running postgres
 	PostgresHost string `json:"postgresHost"`
-	//PostgresPort is the port on which the database server is listening
-	PostgresPort int `json:"postgresPort"`
+	//PostgresPort is the port on which the database server is listening (defaults: 5432)
+	PostgresPort int `json:"postgresPort,omitempty"`
 	//PostgresDB is the database within postgres we're using
 	PostgresDB string `json:"postgresDB"`
 	// PostgresUser is the name of the secret containing the database username
@@ -33,10 +30,10 @@ type SentrySpec struct {
 
 	// RedisHost is the name of the server running redis
 	RedisHost string `json:"redisHost"`
-	// RedisPort is the port on which the redis server is listening
-	RedisPort int `json:"redisPort"`
-	// RedisDB is the name of the redis instance we're using
-	RedisDB string `json:"redisDB"`
+	// RedisPort is the port on which the redis server is listening (defaults: 6379)
+	RedisPort int `json:"redisPort,omitempty"`
+	// RedisDB is the name of the redis instance we're using (defaults: "0")
+	RedisDB string `json:"redisDB,omitempty"`
 }
 
 // SentryStatus defines the observed state of Sentry
@@ -60,6 +57,28 @@ type Sentry struct {
 
 	Spec   SentrySpec   `json:"spec,omitempty"`
 	Status SentryStatus `json:"status,omitempty"`
+}
+
+// SetDefaults set the default values for the sentry spec
+func (s *Sentry) SetDefaults() {
+
+	sp := &s.Spec
+
+	if sp.SentryImage == "" {
+		sp.SentryImage = "docker.io/sentry:latest"
+	}
+
+	if sp.PostgresPort == 0 {
+		sp.PostgresPort = 5432
+	}
+
+	if sp.RedisPort == 0 {
+		sp.RedisPort = 6379
+	}
+
+	if sp.RedisDB == "" {
+		sp.RedisDB = "0"
+	}
 }
 
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object

--- a/pkg/apis/sentry/v1alpha1/zz_generated.openapi.go
+++ b/pkg/apis/sentry/v1alpha1/zz_generated.openapi.go
@@ -66,16 +66,9 @@ func schema_pkg_apis_sentry_v1alpha1_SentrySpec(ref common.ReferenceCallback) co
 			SchemaProps: spec.SchemaProps{
 				Description: "SentrySpec defines the desired state of Sentry",
 				Properties: map[string]spec.Schema{
-					"name": {
+					"sentryImage": {
 						SchemaProps: spec.SchemaProps{
-							Description: "Name is the distinct name of the Sentry service we're running",
-							Type:        []string{"string"},
-							Format:      "",
-						},
-					},
-					"sentryVersion": {
-						SchemaProps: spec.SchemaProps{
-							Description: "SentryVersion is the version of sentry we are running",
+							Description: "SentryImage is the image of sentry we are running (defaults: docker.io/sentry:latest)",
 							Type:        []string{"string"},
 							Format:      "",
 						},
@@ -89,7 +82,7 @@ func schema_pkg_apis_sentry_v1alpha1_SentrySpec(ref common.ReferenceCallback) co
 					},
 					"postgresPort": {
 						SchemaProps: spec.SchemaProps{
-							Description: "PostgresPort is the port on which the database server is listening",
+							Description: "PostgresPort is the port on which the database server is listening (defaults: 5432)",
 							Type:        []string{"integer"},
 							Format:      "int32",
 						},
@@ -124,20 +117,20 @@ func schema_pkg_apis_sentry_v1alpha1_SentrySpec(ref common.ReferenceCallback) co
 					},
 					"redisPort": {
 						SchemaProps: spec.SchemaProps{
-							Description: "RedisPort is the port on which the redis server is listening",
+							Description: "RedisPort is the port on which the redis server is listening (defaults: 6379)",
 							Type:        []string{"integer"},
 							Format:      "int32",
 						},
 					},
 					"redisDB": {
 						SchemaProps: spec.SchemaProps{
-							Description: "RedisDB is the name of the redis instance we're using",
+							Description: "RedisDB is the name of the redis instance we're using (defaults: \"0\")",
 							Type:        []string{"string"},
 							Format:      "",
 						},
 					},
 				},
-				Required: []string{"name", "sentryVersion", "postgresHost", "postgresPort", "postgresDB", "postgresUser", "postgresPassword", "redisHost", "redisPort", "redisDB"},
+				Required: []string{"postgresHost", "postgresDB", "postgresUser", "postgresPassword", "redisHost"},
 			},
 		},
 		Dependencies: []string{},

--- a/pkg/controller/sentry/sentry_controller.go
+++ b/pkg/controller/sentry/sentry_controller.go
@@ -91,6 +91,8 @@ func (r *ReconcileSentry) Reconcile(request reconcile.Request) (reconcile.Result
 	// Fetch the Sentry instance
 	sentry := &v1alpha1.Sentry{}
 	err := r.client.Get(context.TODO(), request.NamespacedName, sentry)
+	sentry.SetDefaults()
+
 	if err != nil {
 		if errors.IsNotFound(err) {
 			// Request object not found, could have been deleted after reconcile request.
@@ -155,8 +157,9 @@ func (r *ReconcileSentry) deploymentForSentryWebUI(m *v1alpha1.Sentry, name stri
 				},
 				Spec: corev1.PodSpec{
 					Containers: []corev1.Container{{
-						Image: fmt.Sprintf("sentry:%s", m.Spec.SentryVersion),
+						Image: m.Spec.SentryImage,
 						Name:  name,
+						Args:  []string{"run", "web"},
 						Ports: []corev1.ContainerPort{{
 							ContainerPort: 9000,
 							Name:          name,
@@ -172,7 +175,7 @@ func (r *ReconcileSentry) deploymentForSentryWebUI(m *v1alpha1.Sentry, name stri
 							},
 							{
 								Name:  "SENTRY_POSTGRES_PORT",
-								Value: string(m.Spec.PostgresPort),
+								Value: fmt.Sprintf("%d", m.Spec.PostgresPort),
 							},
 							{
 								Name:  "SENTRY_DB_NAME",
@@ -192,7 +195,7 @@ func (r *ReconcileSentry) deploymentForSentryWebUI(m *v1alpha1.Sentry, name stri
 							},
 							{
 								Name:  "SENTRY_REDIS_PORT",
-								Value: string(m.Spec.RedisPort),
+								Value: fmt.Sprintf("%d", m.Spec.RedisPort),
 							},
 							{
 								Name:  "SENTRY_REDIS_DB",
@@ -239,8 +242,9 @@ func (r *ReconcileSentry) deploymentForSentryWorker(m *v1alpha1.Sentry, name str
 				},
 				Spec: corev1.PodSpec{
 					Containers: []corev1.Container{{
-						Image: "sentry:latest",
+						Image: m.Spec.SentryImage,
 						Name:  name,
+						Args:  []string{"run", "worker"},
 						Ports: []corev1.ContainerPort{{
 							ContainerPort: 9000,
 							Name:          name,
@@ -256,7 +260,7 @@ func (r *ReconcileSentry) deploymentForSentryWorker(m *v1alpha1.Sentry, name str
 							},
 							{
 								Name:  "SENTRY_POSTGRES_PORT",
-								Value: string(m.Spec.PostgresPort),
+								Value: fmt.Sprintf("%d", m.Spec.PostgresPort),
 							},
 							{
 								Name:  "SENTRY_DB_NAME",
@@ -276,7 +280,7 @@ func (r *ReconcileSentry) deploymentForSentryWorker(m *v1alpha1.Sentry, name str
 							},
 							{
 								Name:  "SENTRY_REDIS_PORT",
-								Value: string(m.Spec.RedisPort),
+								Value: fmt.Sprintf("%d", m.Spec.RedisPort),
 							},
 							{
 								Name:  "SENTRY_REDIS_DB",
@@ -323,8 +327,9 @@ func (r *ReconcileSentry) deploymentForSentryCron(m *v1alpha1.Sentry, name strin
 				},
 				Spec: corev1.PodSpec{
 					Containers: []corev1.Container{{
-						Image: "sentry:latest",
+						Image: m.Spec.SentryImage,
 						Name:  name,
+						Args:  []string{"run", "cron"},
 						Ports: []corev1.ContainerPort{{
 							ContainerPort: 9000,
 							Name:          name,
@@ -340,7 +345,7 @@ func (r *ReconcileSentry) deploymentForSentryCron(m *v1alpha1.Sentry, name strin
 							},
 							{
 								Name:  "SENTRY_POSTGRES_PORT",
-								Value: string(m.Spec.PostgresPort),
+								Value: fmt.Sprintf("%d", m.Spec.PostgresPort),
 							},
 							{
 								Name:  "SENTRY_DB_NAME",
@@ -360,7 +365,7 @@ func (r *ReconcileSentry) deploymentForSentryCron(m *v1alpha1.Sentry, name strin
 							},
 							{
 								Name:  "SENTRY_REDIS_PORT",
-								Value: string(m.Spec.RedisPort),
+								Value: fmt.Sprintf("%d", m.Spec.RedisPort),
 							},
 							{
 								Name:  "SENTRY_REDIS_DB",


### PR DESCRIPTION
Few things:

* replaced `string(someInt)` with `fmt.Sprintf` so it doesn't try to
  cast the int to an ascii value
* default values in the spec definition means a shorter spec
* right arguments in the pod definitions so each deployment actually
  runs the right process